### PR TITLE
Fix 'by' line being changed on update, it goes against the norm

### DIFF
--- a/lua/42header/utils/init.lua
+++ b/lua/42header/utils/init.lua
@@ -125,7 +125,7 @@ end
 --- Update an existing header in the current buffer.
 -- @param header The updated header to replace the existing one.
 function M.update_header(header)
-  local immutable = { 8 }
+  local immutable = { 6, 8 }
 
   -- Copies immutable lines from existing header to updated header.
   for _, value in ipairs(immutable) do


### PR DESCRIPTION
I have compared it with the original official vim plugin, and it does not change the 'by' line.
I'm pretty sure it's supposed to contain the author/creator name and email and not the information about the last person who updated the file.